### PR TITLE
Feature/speed up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## NEXT
+
+* Loads vagrent cache into IntervalTree to speed up processing by:
+  * reducing redundant/random disk access
+  * reducing repeated decompression of same data when events are local to each other
+
 ## 3.3.5
 
 * fixing pipefail issue for non-bash environments, splitting command into 2 separate executions.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -55,6 +55,7 @@ WriteMakefile(
                     'Sort::Key' => '1.33',
                     'TAP::Harness' => '3.33',
                     'Try::Tiny' => '0.22',
+                    'Set::IntervalTree' => '0.12',
                    }
 );
 

--- a/bin/AnnotateVcf.pl
+++ b/bin/AnnotateVcf.pl
@@ -404,9 +404,11 @@ sub make_process_log {
 
 sub get_annotator {
 	my $options = shift;
+  my $sorted = $options->{'sorted'};
+  $sorted = 1 if(-e $options->{'input'}.'.tbi');
 
   # creating an EnsemblTranscriptSource using the Ensembl registry
-	my $ts = Sanger::CGP::Vagrent::TranscriptSource::FileBasedTranscriptSource->new('cache' => $options->{'cache'});
+	my $ts = Sanger::CGP::Vagrent::TranscriptSource::FileBasedTranscriptSource->new('cache' => $options->{'cache'}, 'sorted' => $sorted);
 
 	# creating an AnnotatorCollection
 	my $annotator = Sanger::CGP::Vagrent::Annotators::AnnotatorCollection->new(
@@ -473,7 +475,7 @@ sub option_builder {
     'p|process=n' => \$opts{'process'},
     'sp|species=s' => \$opts{'species'},
     'as|assembly=s' => \$opts{'assembly'},
-
+    'u|sorted' => \$opts{'sorted'},
   );
 
   pod2usage() if($opts{'help'});
@@ -536,5 +538,7 @@ AnnotateVcf.pl [-h] [-t] -i <IN_FILE> -o <OUT_FILE> -c <VAGRENT_CACHE_FILE> [-sp
     --process   (-p)      ID_PROCESS that generated this file
 
     --tabix     (-t)      bgzip and tabix index the output file (will generate the .gz version of the -o option)
+
+    --sorted    (-s)      Input is sorted - lower memory requirement, automatic if *.tbi found
 
 =cut

--- a/lib/Sanger/CGP/Vagrent/TranscriptSource/FileBasedTranscriptSource.pm
+++ b/lib/Sanger/CGP/Vagrent/TranscriptSource/FileBasedTranscriptSource.pm
@@ -31,9 +31,7 @@ use Const::Fast qw(const);
 
 use Bio::DB::HTS;
 use Bio::DB::HTS::Tabix;
-
 use Set::IntervalTree;
-use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
 
 use Sanger::CGP::Vagrent::Data::Transcript;
 use Sanger::CGP::Vagrent::Data::Exon;


### PR DESCRIPTION
Relates to #35.

Loading `vagrent.cache.gz` by chromosome into an interval tree and converting the string object representation into an object (and adding `cdnaseq`) only when used the number of disk accesses via tabix are considerably reduced.

This results in a large reduction in run time.

* GRCh37 WGS
  * was _**17**_ min (50MB RAM)
  * now _**9**_ min (120MB/900MB RAM, sorted/unsorted)
* GRCh38 WGS (with e91)
  * was _**76**_ min (50MB RAM)
  * now _**12**_ min (140MB/1GB RAM, sorted/unsorted)

By default the higher memory footprint would be used, unless a `*.tbi` file is detected for the input.  User can indicate input is sorted with `-s` option.